### PR TITLE
Update status options and add display of old status

### DIFF
--- a/src/components/Form.vue
+++ b/src/components/Form.vue
@@ -176,6 +176,10 @@
             ></b-datepicker>
           </b-field>
 
+          <b-field label="Previous status" :type="{ 'is-success': data.currentstatus }">
+            <b-tag type="text" size="is-medium">{{data.currentstatus}}</b-tag>
+          </b-field>
+
           <b-field label="Status" :type="{ 'is-success': data.currentstatus }">
             <b-select placeholder="Select a status" required v-model="data.currentstatus">
               <option v-for="status in STATUSES" :key="status" :value="status">{{ status }}</option>

--- a/src/definitions.js
+++ b/src/definitions.js
@@ -96,19 +96,12 @@ export const COLUMNS_TO_LABELS = {
 };
 
 export const STATUSES = [
-  "Data requested - no response",
-  "Data requested - in process",
-  "Data received - incomplete",
-  "Data received - no errors",
-  "Data ready for analysis",
-];
-
-const STATUS_PAIRS = [
-  ("Data requested - no response", "Data requested - no response"),
-  ("Data requested - in process", "Data requested - in process"),
-  ("Data received - incomplete", "Data received - incomplete"),
-  ("Data received - no errors", "Data received - no errors"),
-  ("Data ready for analysis", "Data ready for analysis"),
+  "Requested",
+  "Requested - No Response",
+  "Received - Incomplete",
+  "Contesting",
+  "Processing",
+  "Analyzing",
 ];
 
 export const CONTACT_METHODS = ["Phone", "Email", "Fax", "Portal"];


### PR DESCRIPTION
> 3) We'd like to change the "Status" variable to:

> Requested
> Requested - No Response
> Received - Incomplete
> Contesting
> Processing
> Analyzing

Also, display new `Previous status` field allowing for easy transfer to new set of options.

<img width="709" alt="Screen Shot 2020-05-10 at 10 24 26 PM" src="https://user-images.githubusercontent.com/26425483/81526798-85fc8c00-930d-11ea-9c94-16cf5ebe70ea.png">
